### PR TITLE
Add automatic theme switching based on time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "22.x",
+        "@types/node": "^22.19.17",
         "@types/vscode": "^1.118.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "*"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -28,13 +30,13 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.118.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "22.x",
-    "typescript-eslint": "^8.56.1",
+    "@types/node": "^22.19.17",
+    "@types/vscode": "^1.118.0",
+    "@vscode/test-cli": "^0.0.12",
+    "@vscode/test-electron": "^2.5.2",
     "eslint": "^9.39.3",
     "typescript": "^5.9.3",
-    "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2"
+    "typescript-eslint": "^8.56.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,49 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "smart-theme-switcher" is now active!');
+    console.log("Smart Theme Switcher ACTIVADO");
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('smart-theme-switcher.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from smart-theme-switcher!');
-	});
+    function getThemeByHour(): string {
+        const hour = new Date().getHours();
 
-	context.subscriptions.push(disposable);
+        console.log("Hora actual:", hour);
+
+        if (hour >= 6 && hour < 12) {
+            return 'Default Light+';
+        } else if (hour >= 12 && hour < 18) {
+            return 'Default Dark+';
+        } else {
+            return 'Abyss';
+        }
+    }
+
+    async function applyTheme() {
+        const theme = getThemeByHour();
+
+        console.log("Tema seleccionado:", theme);
+
+        try {
+            await vscode.workspace.getConfiguration().update(
+                "workbench.colorTheme",
+                theme,
+                vscode.ConfigurationTarget.Global
+            );
+
+            console.log("Tema aplicado correctamente ✅");
+
+        } catch (error) {
+            console.error("Error aplicando tema:", error);
+        }
+    }
+
+    // Ejecutar al iniciar
+    applyTheme();
+
+    // Opcional: re-evaluar cada 5 minutos
+    setInterval(() => {
+        applyTheme();
+    }, 5 * 60 * 1000);
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
+		"strict": true,
+		"types": ["node"]
+		/* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
This feature automatically changes the VS Code theme based on the current time of day.

- Morning: Light theme
- Afternoon: Abyss theme
- Night: Dark theme

Closes #2