### PR TITLE
Add location based theme switching using sunrise/sunset

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,12 @@
 import * as vscode from 'vscode';
 
+type SunriseResponse = {
+	results: {
+		sunrise: string;
+		sunset: string;
+	};
+};
+
 export function activate(context: vscode.ExtensionContext) {
 
     console.log("Smart Theme Switcher ACTIVADO");
@@ -8,20 +15,45 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let autoEnabled = context.globalState.get<boolean>("autoEnabled", true);
 
-    function getThemeByHour(): string {
-		const config = vscode.workspace.getConfiguration("smartTheme");
+    async function getThemeByLocation(): Promise<string> {
+        const config = vscode.workspace.getConfiguration("smartTheme");
 
-		const morning = config.get<string>("morningTheme") || "Default Light+";
-		const afternoon = config.get<string>('afternoonTheme') || "Default Dark+";
-		const night = config.get<string>("nightTheme") || "Abyss";
+        const morning = config.get<string>("morningTheme") || "Default Light+";
+        const afternoon = config.get<string>("afternoonTheme") || "Default Dark+";
+        const night = config.get<string>("nightTheme") || "Abyss";
 
-        const hour = new Date().getHours();
+        try {
+           
+            const lat = 14.0723;
+            const lng = -87.1921;
 
-        if (hour >= 6 && hour < 12) {
-            return morning;
-        } else if (hour >= 12 && hour < 18) {
-            return afternoon;
-        } else {
+            const response = await fetch(
+                `https://api.sunrise-sunset.org/json?lat=${lat}&lng=${lng}&formatted=0`
+            );
+
+            const data = await response.json() as SunriseResponse;
+
+			if (!data?.results) {
+				throw new Error("Invalid API response");
+			}
+
+            const sunrise = new Date(data.results.sunrise);
+            const sunset = new Date(data.results.sunset);
+            const now = new Date();
+
+            if (now >= sunrise && now < sunset) {
+                return morning;
+            }
+
+            return night;
+
+        } catch (error) {
+            console.log("Fallback a hora local:", error);
+
+            const hour = new Date().getHours();
+
+            if (hour >= 6 && hour < 12) return morning;
+            if (hour >= 12 && hour < 18) return afternoon;
             return night;
         }
     }
@@ -30,6 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		//validar si esta desactivado desde settings
 		const enabledFromSettings = settings.get<boolean>("enabled") ?? true;
+
 		if (!enabledFromSettings || !autoEnabled) {
 			console.log("Extension desactivada");
 			return;
@@ -37,7 +70,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 		const config = vscode.workspace.getConfiguration();
 		const currentTheme = config.get<string>("workbench.colorTheme") || "";
-		const newTheme = getThemeByHour();
+		
+		const newTheme = await getThemeByLocation();
 
 		console.log("Tema actual:", currentTheme);
 		console.log("Tema esperado:", newTheme);
@@ -78,6 +112,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	if (autoEnabled) {
 		interval = setInterval(() => {
+
+			console.log("Revisando cambio de tema")
 			applyTheme();
 		}, 5 * 60 * 1000);
 


### PR DESCRIPTION
loses #9

Implements theme switching based on sunrise and sunset times using external API.

Changes:
- Replaces static time logic with sunrise/sunset API
- Adds fallback to local time when API fails
- Adds type safety for API response
- Improves accuracy of theme switching based on real daylight cycle

Behavior:
- Daytime: applies morning theme
- Nighttime: applies night theme
- Fallback: uses system time if API is unavailable